### PR TITLE
Version 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Zigvale is a Zig implementation of the stivale2 boot protocol to be used both in
 
 ## Add to your project
 
-Zigvale is available on [aquila](https://aquila.red/1/Ominitay/zigvale), [zpm](https://zig.pm/#/package/zigvale), and [astrolabe](https://astrolabe.pm/#/package/ominitay/zigvale/0.3.1).
+Zigvale is available on [aquila](https://aquila.red/1/Ominitay/zigvale), [zpm](https://zig.pm/#/package/zigvale), and [astrolabe](https://astrolabe.pm/#/package/ominitay/zigvale/0.4.0).
 
 ### Gyro
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ comptime {
     @export(entry, .{ .name = "_start", .linkage = .Strong });
 }
 
-pub fn kmain(_: *zigvale.Struct.Parsed) noreturn {
+pub fn kmain(_: *const zigvale.Struct.Parsed) noreturn {
     while (true) {}
 }
 ```

--- a/build.zig
+++ b/build.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) void {
+    const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
 
     const lib_tests = b.addTest("zigvale.zig");
+    lib_tests.setTarget(target);
     lib_tests.setBuildMode(mode);
 
     const lib_test_doc = lib_tests;

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,6 +1,6 @@
 pkgs:
   zigvale:
-    version: 0.3.1
+    version: 0.4.0
     root: zigvale.zig
     description: A Zig implementation of the stivale2 boot protocol.
     license: mit

--- a/src/stivale2.zig
+++ b/src/stivale2.zig
@@ -535,7 +535,7 @@ pub const Struct = packed struct {
 
     pub const SmpInfo = packed struct {
         /// ACPI processor UID as specified by MADT
-        acpi_processor_uid: u32,
+        processor_id: u32,
         /// LAPIC ID as specified by MADT
         lapic_id: u32,
         /// The stack that will be loaded in ESP/RSP once the goto_address field is loaded. This **MUST** point

--- a/src/stivale2.zig
+++ b/src/stivale2.zig
@@ -97,9 +97,9 @@ pub const Header = packed struct {
     /// text mode, and the bootloader will refuse to boot the kernel if that cannot be fulfilled.
     pub const FramebufferTag = packed struct {
         tag: Tag = .{ .identifier = .framebuffer },
-        width: u16,
-        height: u16,
-        bpp: u16,
+        width: u16 = 0,
+        height: u16 = 0,
+        bpp: u16 = 0,
         unused: u16 = 0,
     };
 
@@ -113,7 +113,7 @@ pub const Header = packed struct {
     /// or text mode.
     pub const TerminalTag = packed struct {
         tag: Tag = .{ .identifier = .terminal },
-        flags: @This().Flags,
+        flags: @This().Flags = .{},
         /// Address of the terminal callback function
         callback: u64,
 
@@ -128,7 +128,7 @@ pub const Header = packed struct {
     /// This tag enables support for booting up application processors.
     pub const SmpTag = packed struct {
         tag: Tag = .{ .identifier = .smp },
-        flags: @This().Flags,
+        flags: @This().Flags = .{},
 
         pub const Flags = packed struct {
             /// Use xAPIC

--- a/src/stivale2.zig
+++ b/src/stivale2.zig
@@ -115,13 +115,25 @@ pub const Header = packed struct {
         tag: Tag = .{ .identifier = .terminal },
         flags: @This().Flags = .{},
         /// Address of the terminal callback function
-        callback: u64,
+        callback: ?fn (CallbackType, u64, u64, u64) callconv(.C) void = null,
 
         pub const Flags = packed struct {
             /// Set if a callback function is provided
             callback: u1 = 0,
             /// Undefined and must be set to 0.
             zeros: u63 = 0,
+        };
+
+        /// These are the possible types which the terminal callback function may have to deal with.
+        pub const CallbackType = enum(u64) {
+            dec = 10,
+            bell = 20,
+            private_id = 30,
+            status_report = 40,
+            pos_report = 50,
+            kbd_leds = 60,
+            mode = 70,
+            linux = 80,
         };
     };
 
@@ -401,7 +413,7 @@ pub const Struct = packed struct {
         cols: u16,
         rows: u16,
         /// Pointer to the entry point of the `stivale2_term_write()` function.
-        term_write: u64,
+        term_write: fn (ptr: [*]const u8, length: u64) callconv(.C) void,
         /// If `Flags.max_length` is set, this field specifies the maximum allowed string length to be passed
         /// to `term_write()`. If this is 0, then there is limit.
         max_length: u64,
@@ -492,7 +504,7 @@ pub const Struct = packed struct {
     pub const KernelFileTag = packed struct {
         tag: Tag = .{ .identifier = .kernel_file },
         /// Address of the kernel file
-        kernel_file: u64,
+        kernel_file: [*]const u8,
     };
 
     /// This tag provides the kernel with a pointer to a copy of the executable file of the kernel, along with
@@ -500,7 +512,7 @@ pub const Struct = packed struct {
     pub const KernelFileV2Tag = packed struct {
         tag: Tag = .{ .identifier = .kernel_file_v2 },
         /// Address of the kernel file
-        kernel_file: u64,
+        kernel_file: [*]const u8,
         /// Size of the kernel file
         kernel_size: u64,
     };

--- a/src/stivale2.zig
+++ b/src/stivale2.zig
@@ -220,6 +220,7 @@ pub const Struct = packed struct {
     pub const Parsed = struct {
         bootloader_brand: []const u8,
         bootloader_version: []const u8,
+        first: ?*const Tag = null,
         pmrs: ?*const PmrsTag = null,
         cmdline: ?*const CmdlineTag = null,
         memmap: ?*const MemmapTag = null,
@@ -249,6 +250,7 @@ pub const Struct = packed struct {
         var parsed = Parsed{
             .bootloader_brand = std.mem.sliceTo(&self.bootloader_brand, 0),
             .bootloader_version = std.mem.sliceTo(&self.bootloader_version, 0),
+            .first = self.tags,
         };
 
         var tag_opt = self.tags;

--- a/src/stivale2.zig
+++ b/src/stivale2.zig
@@ -515,6 +515,11 @@ pub const Struct = packed struct {
         kernel_file: [*]const u8,
         /// Size of the kernel file
         kernel_size: u64,
+
+        /// Returns a slice over the kernel file
+        pub fn asSlice(self: KernelFileV2Tag) []const u8 {
+            return self.kernel_file[0..self.kernel_size];
+        }
     };
 
     /// This tag provides the kernel with the slide that the bootloader has applied to the kernel's address
@@ -630,6 +635,16 @@ test "Struct Other Sizes" {
     try expect(@bitSizeOf(Struct.MemmapEntry) == 192);
     try expect(@bitSizeOf(Struct.Module) == 1152);
     try expect(@bitSizeOf(Struct.SmpInfo) == 256);
+}
+
+test "KernelFileV2Tag asSlice" {
+    const string: []const u8 = "Hello world!";
+    const kernel_file_v2_tag = Struct.KernelFileV2Tag{
+        .kernel_file = string.ptr,
+        .kernel_size = string.len,
+    };
+
+    try expect(std.mem.eql(u8, string, kernel_file_v2_tag.asSlice()));
 }
 
 // We use this only as a helper for our test


### PR DESCRIPTION
## Features:
- Added target argument to `zig build`
- Added `asSlice` to `KernelFileV2Tag`
- Added print function and writer to `TerminalTag`
- Added pointer to first tag to `Struct.Parsed`

## Fixes:
- Variable name changed to match spec (processor_id)
- Added default values to some tags
- Replaced u64 types with more appropriate types

## Docs:
- Fixed kmain function signature in example