### PR TITLE
correct `Header.entry_point` default value

### DIFF
--- a/src/stivale2.zig
+++ b/src/stivale2.zig
@@ -41,7 +41,7 @@ test "TagGeneric" {
 /// The kernel must have a section `.stivale2hdr` either containing a header, or an anchor pointing to one.
 pub const Header = packed struct {
     /// The address to be jumped to as the entry point of the kernel. If 0, the ELF entry point will be used.
-    entry_point: ?fn (*const Struct) callconv(.C) noreturn = 0,
+    entry_point: ?fn (*const Struct) callconv(.C) noreturn = null,
     /// The stack address which will be in ESP/RSP when the kernel is loaded.
     /// The stack must be at least 256 bytes, and must have a 16 byte aligned address.
     stack: ?*u8,


### PR DESCRIPTION
fixes #24